### PR TITLE
Cmor::Testimonials: Let ApplicationViewHelper#render_category accept …

### DIFF
--- a/cmor_testimonials/app/assets/stylesheets/cmor/testimonials/application/carousel.css
+++ b/cmor_testimonials/app/assets/stylesheets/cmor/testimonials/application/carousel.css
@@ -4,12 +4,12 @@
 }
 
 
-.carousel-control-prev-icon:before {
+.carousel-control-prev:before {
   content:"\2039";
   font-size: 250%;
 }
 
-.carousel-control-next-icon:before {
+.carousel-control-next:before {
   content:"\203A";
   font-size: 250%;
 }

--- a/cmor_testimonials/app/models/cmor/testimonials/category.rb
+++ b/cmor_testimonials/app/models/cmor/testimonials/category.rb
@@ -7,6 +7,9 @@ module Cmor
         end
       end
 
+      scope :with, ->(type) { joins(type) }
+      scope :with_published_testimonials, -> { with(:testimonials).merge(Testimonial.published) }
+
       validates :locale, presence: true, inclusion: { in: I18n.available_locales.map(&:to_s) }
       validates :identifier, presence: true, uniqueness: { scope: [ :locale ] }
       validates :name, presence: true, uniqueness: { scope: [ :locale ] }

--- a/cmor_testimonials/app/view_helpers/cmor/testimonials/application_view_helper.rb
+++ b/cmor_testimonials/app/view_helpers/cmor/testimonials/application_view_helper.rb
@@ -1,7 +1,7 @@
 module Cmor
   module Testimonials
     class ApplicationViewHelper < Rao::ViewHelper::Base
-      def render_category(identifier, options = {})
+      def render_category(category_or_identifier, options = {})
         default_variant_options = Cmor::Testimonials::Configuration.image_variant_options[:category]
         options.reverse_merge!(
           autostart:       true,
@@ -15,17 +15,15 @@ module Cmor
           variant_options: default_variant_options,
           font_awesome:    false
         )
-        category = Cmor::Testimonials::Category.where(identifier: identifier).first
+        category = if category_or_identifier.is_a?(Cmor::Testimonials::Category)
+          category_or_identifier
+        else
+          Cmor::Testimonials::Category.where(identifier: category_or_identifier).first
+        end
 
         if category.present? && category.testimonials.published.any?
           render category: category, options: options
         end
-      end
-
-      private
-
-      def render(locals = {})
-        c.render partial: "/#{self.class.name.underscore}/#{caller_locations(1,1)[0].label}", locals: locals
       end
     end
   end

--- a/cmor_testimonials/app/views/cmor/testimonials/application_view_helper/_render_category.html.haml
+++ b/cmor_testimonials/app/views/cmor/testimonials/application_view_helper/_render_category.html.haml
@@ -14,15 +14,11 @@
         %p.overview
           = "<b>#{testimonial.fullname}</b>, #{testimonial.role} - #{testimonial.company}".html_safe
   - if options[:controls]
-    %a.carousel-control-prev{"data-slide" => "prev", :href => "##{dom_id(category)}", :role => "button"}
-      - if options[:font_awesome]
-        %i.fa.fa-angle-left
-      - else
-        %span.carousel-control-prev-icon{"aria-hidden" => "true"}
+    - if options[:font_awesome]
+      %i.fa.fa-angle-left
+      %i.fa.fa-angle-right
+    - else
+      %a.carousel-control-prev{"data-slide" => "prev", :href => "##{dom_id(category)}", :role => "button"}
         %span.sr-only= t('.previous')
-    %a.carousel-control-next{"data-slide" => "next", :href => "##{dom_id(category)}", :role => "button"}
-      - if options[:font_awesome]
-        %i.fa.fa-angle-right
-      - else
-        %span.carousel-control-next-icon{"aria-hidden" => "true"}
+      %a.carousel-control-next{"data-slide" => "next", :href => "##{dom_id(category)}", :role => "button"}
         %span.sr-only= t('.next')

--- a/cmor_testimonials/config/locales/de.yml
+++ b/cmor_testimonials/config/locales/de.yml
@@ -33,7 +33,7 @@ de:
   cmor:
     testimonials:
       application_view_helper:
-        render:
+        render_category:
           next: Vor
           previous: Zurück
   routes:

--- a/cmor_testimonials/config/locales/en.yml
+++ b/cmor_testimonials/config/locales/en.yml
@@ -33,7 +33,7 @@ en:
   cmor:
     testimonials:
       application_view_helper:
-        render:
+        render_category:
           next: Next
           previous: Previous
   routes:

--- a/cmor_testimonials/spec/view_helpers/cmor/testimonials/application_view_helper_spec.rb
+++ b/cmor_testimonials/spec/view_helpers/cmor/testimonials/application_view_helper_spec.rb
@@ -1,15 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Cmor::Testimonials::ApplicationViewHelper, type: :view_helper do
-  let(:category) { create(:cmor_testimonials_category, testimonials: testimonials) }
-  let(:args) { [category.identifier, {}] }
-
   before(:each) do
     register_view_helper Markup::Rails::ApplicationViewHelper, as: :markup_helper
   end
   
   context 'testimonials present' do
     let(:testimonials) { create_list(:cmor_testimonials_testimonial, 3) }
+    let(:category) { create(:cmor_testimonials_category, testimonials: testimonials) }
+    let(:args) { [category.identifier, {}] }
 
     describe 'render_category' do
       it { expect(html).to have_css('div.cmor-testimonials-category') }
@@ -18,9 +17,21 @@ RSpec.describe Cmor::Testimonials::ApplicationViewHelper, type: :view_helper do
 
   context 'testimonials absent' do
     let(:testimonials) {[]}
+    let(:category) { create(:cmor_testimonials_category, testimonials: testimonials) }
+    let(:args) { [category.identifier, {}] }
 
     describe 'render_category' do
       it { expect(rendered).to eq(nil) }
+    end
+  end
+
+  context 'when using a category as first argument' do
+    let(:testimonials) { create_list(:cmor_testimonials_testimonial, 3) }
+    let(:category) { create(:cmor_testimonials_category, testimonials: testimonials) }
+    let(:args) { [category, {}] }
+
+    describe 'render_category' do
+      it { expect(html).to have_css('div.cmor-testimonials-category') }
     end
   end
 end


### PR DESCRIPTION
…a category as first argument. Closes #19

Cmor::Testimonials: Fix double arrows in ApplicationViewHelper#render_category.
Cmor::Testimonials: Remove obsolete code.
Cmor::Testimonials: Fix missing translations.